### PR TITLE
Fixed slow tests

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ ARG GROUP_ID
 RUN addgroup --gid $GROUP_ID developer
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID developer
 
+ENV PATH="/home/developer/.local/bin:${PATH}"
+
 USER developer
 WORKDIR /home/developer/tuned-lens
 
@@ -59,7 +61,7 @@ WORKDIR /home/developer/tuned-lens
 # docker run tuned-lens-test
 
 # Using the development image
-# docker build -t tuned-lens-dev --target dev . 
-# docker run -it tuned-lens-dev --mount type=bind,source="$(pwd)",target=.
+# docker build -t tuned-lens-dev --target dev --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) .
+# docker run -it tuned-lens-dev --mount type=bind,source="$(pwd)",target=/home/developer/tuned-lens
 # Note: You will still need to install the package in the container in development mode
 # Warning: Don't push the development image to a public registry

--- a/README.md
+++ b/README.md
@@ -1,23 +1,4 @@
 # tuned-lens
-Tools for understanding how transformer predictions are built layer-by-layer.
+Tools for understanding how transformer predictions are built layer-by-layer
 
 <img width="1028" alt="tuned lens" src="https://user-images.githubusercontent.com/39116809/206883419-4fb9083d-3fa0-48e9-ba97-b70cb21b08e9.png">
-
-## Installation instructions
-### Perquisite
-* Python 3.9+
-* Pytorch 1.12.0+
-
-### Installing from source
-```
-git clone https://github.com/norabelrose/tuned-lens
-cd tuned-lens
-pip install .
-```
-
-## Basic usage
-TODO
-
-
-## Citation
-Forthcoming

--- a/README.md
+++ b/README.md
@@ -1,4 +1,23 @@
 # tuned-lens
-Tools for understanding how transformer predictions are built layer-by-layer
+Tools for understanding how transformer predictions are built layer-by-layer.
 
 <img width="1028" alt="tuned lens" src="https://user-images.githubusercontent.com/39116809/206883419-4fb9083d-3fa0-48e9-ba97-b70cb21b08e9.png">
+
+## Installation instructions
+### Perquisite
+* Python 3.9+
+* Pytorch 1.12.0+
+
+### Installing from source
+```
+git clone https://github.com/norabelrose/tuned-lens
+cd tuned-lens
+pip install .
+```
+
+## Basic usage
+TODO
+
+
+## Citation
+Forthcoming

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ version = "0.0.1"
 [project.optional-dependencies]
 dev = [
     "pre-commit",
+    "pytest-skip-slow",
     "pytest",
 ]
 
@@ -31,3 +32,6 @@ tuned-lens = "tuned_lens.__main__:run"
 
 [tool.setuptools]
 packages = ["tuned_lens"]
+
+[tool.pytest.ini_options]
+addini = "slow : mark tests as slow these will be skipped by default"

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -20,6 +20,8 @@ def correctness(model_str: str):
     decoder = Decoder(model)
     if model_str.startswith("facebook/opt"):
         ln_f = model.base_model.decoder.final_layer_norm
+    elif model_str.startswith("EleutherAI/pythia-125m"):
+        ln_f = model.base_model.final_layer_norm
     else:
         ln_f = model.base_model.ln_f
 
@@ -32,19 +34,19 @@ def correctness(model_str: str):
     th.testing.assert_close(y.exp(), decoder(x_hat).softmax(-1), atol=5e-4, rtol=0.01)
    
 
-def test_correctness_fast():
-    correctness("EleutherAI/pythia-125m")
-
 @pytest.mark.slow
+def test_correctness_slow():
+    correctness("EleutherAI/gpt-j-6B")
+
 @pytest.mark.parametrize(
     "model_str",
     [
+        "EleutherAI/pythia-125m",
         "bigscience/bloom-560m",
-        "EleutherAI/gpt-j-6B",
         "EleutherAI/gpt-neo-125M",
         "facebook/opt-125m",
         "gpt2",
     ],
 )
-def test_correctness_slow(model_str: str):
+def test_correctness(model_str: str):
     correctness(model_str)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -3,19 +3,7 @@ from transformers import AutoConfig, AutoModelForCausalLM
 import pytest
 import torch as th
 
-
-@pytest.mark.parametrize(
-    "model_str",
-    [
-        "bigscience/bloom-560m",
-        "EleutherAI/gpt-j-6B",
-        "EleutherAI/gpt-neo-125M",
-        "EleutherAI/pythia-125m",
-        "facebook/opt-125m",
-        "gpt2",
-    ],
-)
-def test_correctness(model_str: str):
+def correctness(model_str: str):
     th.manual_seed(42)
 
     # We use a random model with the correct config instead of downloading the
@@ -42,3 +30,21 @@ def test_correctness(model_str: str):
 
     x_hat = decoder.back_translate(x, tol=1e-5)
     th.testing.assert_close(y.exp(), decoder(x_hat).softmax(-1), atol=5e-4, rtol=0.01)
+   
+
+def test_correctness_fast():
+    correctness("EleutherAI/pythia-125m")
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "model_str",
+    [
+        "bigscience/bloom-560m",
+        "EleutherAI/gpt-j-6B",
+        "EleutherAI/gpt-neo-125M",
+        "facebook/opt-125m",
+        "gpt2",
+    ],
+)
+def test_correctness_slow(model_str: str):
+    correctness(model_str)


### PR DESCRIPTION
This pull request does two things:
1. First it increases the time-out on GitHub actions to 30 min. 
2. it separates most of the decoder tests into a specific slow test that will only run if `pytest` is passed the `--slow` flag.

Ideally this will close #11 